### PR TITLE
Fix bug of `GetGearShape`

### DIFF
--- a/gear-ui/src/main/java/com/example/gear/ui/shape/GetGearShape.kt
+++ b/gear-ui/src/main/java/com/example/gear/ui/shape/GetGearShape.kt
@@ -37,7 +37,15 @@ private fun cornerRoundings(
         toothRounding,
         toothRounding,
         CornerRounding.Unrounded,
-    ).take(numVertices)
+    ) * numVertices
+
+private operator fun List<CornerRounding>.times(another: Int): List<CornerRounding> {
+    var result = emptyList<CornerRounding>()
+    for (i in 0 until another) {
+        result = result + this
+    }
+    return result
+}
 
 private fun getGearVertices(
     numVertices: Int,


### PR DESCRIPTION
# Issue

AS-IS: Throw exception by incorrect size of `CornerRounding`
TO-BE: Make size of `CornerRounding` is same with `Vertices`