### PR TITLE
Add annotation for blocking too small radius

### DIFF
--- a/gear-ui/src/main/java/com/example/gear/ui/shape/GetGearShape.kt
+++ b/gear-ui/src/main/java/com/example/gear/ui/shape/GetGearShape.kt
@@ -1,6 +1,7 @@
 package com.example.gear.ui.shape
 
 import android.graphics.PointF
+import androidx.annotation.FloatRange
 import androidx.core.graphics.times
 import androidx.graphics.shapes.CornerRounding
 import androidx.graphics.shapes.RoundedPolygon
@@ -9,8 +10,8 @@ import kotlin.math.sin
 
 fun getGearShape(
     numTeeth: Int,
-    teethRadius: Float,
-    wheelRadius: Float,
+    @FloatRange(from = 0.001) teethRadius: Float,
+    @FloatRange(from = 0.001) wheelRadius: Float,
     centerX: Float,
     centerY: Float,
     toothRounding: CornerRounding = CornerRounding.Unrounded


### PR DESCRIPTION
In order to avoid issue of vertices including zero vector

```
Process: com.example.androidsandbox.demo.debug, PID: 28953
                                                                                                    java.lang.IllegalArgumentException: Can't get the direction of a 0-length vector
                                                                                                    	at androidx.graphics.shapes.PointKt.getDirection-DnnuFBc(Point.kt:63)
                                                                                                    	at androidx.graphics.shapes.RoundedCorner.<init>(RoundedPolygon.kt:475)
                                                                                                    	at androidx.graphics.shapes.RoundedCorner.<init>(Unknown Source:0)
                                                                                                    	at androidx.graphics.shapes.RoundedPolygonKt.RoundedPolygon(RoundedPolygon.kt:326)
                                                                                                    	at androidx.graphics.shapes.RoundedPolygonKt.RoundedPolygon$default(RoundedPolygon.kt:299)
```